### PR TITLE
SettingsPanelMixin:OpenToCategory Extension for Sub Category IDs

### DIFF
--- a/Interface/SharedXML/Settings/Blizzard_SettingsPanel.lua
+++ b/Interface/SharedXML/Settings/Blizzard_SettingsPanel.lua
@@ -388,7 +388,8 @@ local function FindCategoryByCategoryID(categories, categoryID)
 			if category:GetID() == categoryID then
 				return category;
 			else
-				FindCategoryByCategoryID(category:GetSubcategories(), categoryID);
+				local subcategory = FindCategoryByCategoryID(category:GetSubcategories(), categoryID);
+				if subcategory then return subcategory; end
 			end
 		end
 	end

--- a/Interface/SharedXML/Settings/Blizzard_SettingsPanel.lua
+++ b/Interface/SharedXML/Settings/Blizzard_SettingsPanel.lua
@@ -382,18 +382,29 @@ function SettingsPanelMixin:Open()
 	end
 end
 
+local function FindCategoryByCategoryID(categories, categoryID)
+	if categories then
+		for index, category in ipairs(categories) do
+			if category:GetID() == categoryID then
+				return category;
+			else
+				FindCategoryByCategoryID(category:GetSubcategories(), categoryID);
+			end
+		end
+	end
+end
+
 function SettingsPanelMixin:OpenToCategory(categoryID, scrollToElementName)
 	self:Open();
 
-	local categoryTbl = self:GetCategoryList():GetCategory(categoryID);
-	if categoryTbl then
-		self:SelectCategory(categoryTbl);
-
-		if scrollToElementName then
-			self:GetSettingsList():ScrollToElementByName(scrollToElementName);
-		end
+	local categoryTbl = FindCategoryByCategoryID(self:GetAllCategories(), categoryID);
+	if not categoryTbl then return false; end
+	
+	self:SelectCategory(categoryTbl);
+	if scrollToElementName then
+		self:GetSettingsList():ScrollToElementByName(scrollToElementName);
 	end
-	return categoryTbl ~= nil;
+	return true;
 end
 
 function SettingsPanelMixin:SetKeybindingsCategory(category)


### PR DESCRIPTION
This pull request demonstrates the logic adjustment required to provide the SettingsPanelMixin's OpenToCategory function with the ability to also open a sub category for an addon. As it is now, if you try to open a sub category despite knowing its unique CategoryID, the function as designed will not correctly open the sub category. It appears to be strictly limited to the root and root addon categories only.

I recognize that this repository is not meant to receive pull requests, but please incorporate this into the game's API after testing it on your development branch. (Testing the modification on my end is impossible, but I'm fairly confident that it logically should work assuming all of the secure functions behave as I expect them to.)